### PR TITLE
Adding network properties to mobile schema

### DIFF
--- a/Snowplow/SnowplowTracker.m
+++ b/Snowplow/SnowplowTracker.m
@@ -105,7 +105,7 @@ NSString * const kVersion               = @"osx-0.3.1";
 - (void) setMobileContext: (NSMutableArray *)payloadData {
     SnowplowPayload *mobContext = [[SnowplowPayload alloc] init];
 
-    NSString *schema = [NSString stringWithFormat:@"%@%@/mobile_context/jsonschema/1-0-0",
+    NSString *schema = [NSString stringWithFormat:@"%@%@/mobile_context/jsonschema/1-0-1",
                         kIglu, kSnowplowVendor];
 
     [mobContext addValueToPayload:[SnowplowUtils getOSType] forKey:@"osType"];
@@ -116,6 +116,8 @@ NSString * const kVersion               = @"osx-0.3.1";
     [mobContext addValueToPayload:[SnowplowUtils getOpenIdfa] forKey:@"openIdfa"];
     [mobContext addValueToPayload:[SnowplowUtils getAppleIdfa] forKey:@"appleIdfa"];
     [mobContext addValueToPayload:[SnowplowUtils getAppleIdfv] forKey:@"appleIdfv"];
+    [mobContext addValueToPayload:[SnowplowUtils getNetworkType] forKey:@"networkType"];
+    [mobContext addValueToPayload:[SnowplowUtils getNetworkTechnology] forKey:@"networkTechnology"];
 
     NSDictionary *envelope = [NSDictionary dictionaryWithObjectsAndKeys:
                               schema, @"schema",

--- a/Snowplow/SnowplowUtils.h
+++ b/Snowplow/SnowplowUtils.h
@@ -73,6 +73,16 @@
 + (NSString *) getCarrierName;
 
 /**
+ *
+ */
++ (NSString *) getNetworkType;
+
+/**
+ *
+ */
++ (NSString *) getNetworkTechnology;
+
+/**
  *  Generates a randomly generated 6-digit integer.
  *  @return A random 6-digit int.
  */

--- a/Snowplow/SnowplowUtils.m
+++ b/Snowplow/SnowplowUtils.m
@@ -103,6 +103,23 @@
 #endif
 }
 
+
++ (NSString *) getNetworkType {
+#if TARGET_OS_IPHONE
+    return @"wifi";
+#else
+    return @"";
+#endif
+}
+
++ (NSString *) getNetworkTechnology {
+#if TARGET_OS_IPHONE
+    return @"3g";
+#else
+    return @"";
+#endif
+}
+
 + (int) getTransactionId {
     return arc4random() % (999999 - 100000+1) + 100000;
 }

--- a/Snowplow/SnowplowUtils.m
+++ b/Snowplow/SnowplowUtils.m
@@ -106,7 +106,23 @@
 
 + (NSString *) getNetworkType {
 #if TARGET_OS_IPHONE
-    return @"wifi";
+    Reachability *reachability = [Reachability reachabilityForInternetConnection];
+    [reachability startNotifier];
+    
+    NetworkStatus status = [reachability currentReachabilityStatus];
+    
+    if(status == NotReachable)
+    {
+        return @"none";
+    }
+    else if (status == ReachableViaWiFi)
+    {
+        return @"wifi";
+    }
+    else if (status == ReachableViaWWAN)
+    {
+        reutrn @"mobile";
+    }
 #else
     return @"";
 #endif
@@ -114,7 +130,8 @@
 
 + (NSString *) getNetworkTechnology {
 #if TARGET_OS_IPHONE
-    return @"3g";
+    CTTelephonyNetworkInfo *netinfo = [[CTTelephonyNetworkInfo alloc] init];
+    return [netInfo currentRadioAccessTechnology];
 #else
     return @"";
 #endif


### PR DESCRIPTION
Adds two properties to the mobile context, following along with two properties added to the mobileContext schema in https://github.com/snowplow/iglu-central/pull/135. 
