### PR TITLE
Unset payload keys when set with a nil

### DIFF
--- a/Snowplow/SnowplowPayload.m
+++ b/Snowplow/SnowplowPayload.m
@@ -49,6 +49,9 @@
 
 - (void) addValueToPayload:(NSString *)value forKey:(NSString *)key {
     if (value == nil) {
+        if ([_payload valueForKey:key] != nil) {
+            [_payload removeObjectForKey:key];
+        }
         return;
     }
     [_payload setObject:value forKey:key];

--- a/SnowplowTests/TestPayload.m
+++ b/SnowplowTests/TestPayload.m
@@ -128,6 +128,20 @@
                           @"Payload should have the same data as sample_dict_final");
 }
 
+- (void)testAddNilValueToPayload
+{
+    SnowplowPayload *payload = [[SnowplowPayload alloc] init];
+    [payload addValueToPayload:nil forKey:@"foo"];
+    XCTAssertEqualObjects(payload.getPayloadAsDictionary, [[NSDictionary alloc] init]);
+}
+
+- (void)testAddNilValueToPayloadUnsetsKey
+{
+    SnowplowPayload *payload = [[SnowplowPayload alloc] initWithNSDictionary:@{@"foo":@"bar"}];
+    [payload addValueToPayload:nil forKey:@"foo"];
+    XCTAssertEqualObjects(payload.getPayloadAsDictionary, [[NSDictionary alloc] init]);
+}
+
 - (void)testAddDictToPayload
 {
     NSDictionary *sample_dic = [[NSDictionary alloc] initWithObjectsAndKeys:


### PR DESCRIPTION
I checked to see what would happen when a nil was passed in as a new value to a Payload and :boom: the old key stuck around. That was disappointing. 

This fixes the problem and instead unsets the key, which seems closer to being robust in the face of the data presented to the Payload.
